### PR TITLE
feat: add custom color support for QR codes

### DIFF
--- a/app/routers/qr_code_router.py
+++ b/app/routers/qr_code_router.py
@@ -13,10 +13,15 @@ async def create_qr_code(request: QRCodeRequest):
     Generate a QR code from the provided data.
     
     Args:
-        request: QR code generation request containing data and size
+        request: QR code generation request containing data, size, and colors
         
     Returns:
         dict: Contains the base64 encoded QR code image
     """
-    qr_code = generate_qr_code(request.data, request.size)
+    qr_code = generate_qr_code(
+        request.data,
+        request.size,
+        request.fill_color,
+        request.back_color
+    )
     return {"qr_code": qr_code} 

--- a/app/schemas/qr_code_schemas.py
+++ b/app/schemas/qr_code_schemas.py
@@ -6,4 +6,6 @@ from pydantic import BaseModel, Field
 class QRCodeRequest(BaseModel):
     """Schema for QR code generation request."""
     data: str = Field(..., description="The data to encode in the QR code")
-    size: int = Field(default=10, ge=1, le=40, description="QR code size (1-40)") 
+    size: int = Field(default=10, ge=1, le=40, description="QR code size (1-40)")
+    fill_color: str = Field(default="black", description="QR code fill color (any valid color name or hex code)")
+    back_color: str = Field(default="white", description="QR code background color (any valid color name or hex code)") 

--- a/app/services/qr_code_service.py
+++ b/app/services/qr_code_service.py
@@ -5,13 +5,15 @@ import qrcode
 from io import BytesIO
 import base64
 
-def generate_qr_code(data: str, size: int = 10) -> str:
+def generate_qr_code(data: str, size: int = 10, fill_color: str = "black", back_color: str = "white") -> str:
     """
     Generate a QR code and return it as a base64 encoded string.
     
     Args:
         data: The data to encode in the QR code
         size: The size of the QR code (1-40)
+        fill_color: Color of the QR code pattern (default: "black")
+        back_color: Background color (default: "white")
         
     Returns:
         str: Base64 encoded PNG image
@@ -25,7 +27,7 @@ def generate_qr_code(data: str, size: int = 10) -> str:
     qr.add_data(data)
     qr.make(fit=True)
 
-    img = qr.make_image(fill_color="black", back_color="white")
+    img = qr.make_image(fill_color=fill_color, back_color=back_color)
     
     # Convert PIL image to base64
     buffered = BytesIO()

--- a/tests/test_qr_code.py
+++ b/tests/test_qr_code.py
@@ -8,10 +8,32 @@ import base64
 client = TestClient(app)
 
 def test_generate_qr_code():
-    """Test QR code generation endpoint."""
+    """Test QR code generation endpoint with default parameters."""
     response = client.post(
         "/qr/generate",
         json={"data": "https://example.com", "size": 10}
+    )
+    assert response.status_code == 200
+    assert "qr_code" in response.json()
+    
+    # Verify the response contains a valid base64 encoded PNG
+    qr_code = response.json()["qr_code"]
+    try:
+        decoded = base64.b64decode(qr_code)
+        assert decoded.startswith(b"\x89PNG")  # PNG magic number
+    except Exception:
+        assert False, "Invalid base64 encoded PNG image"
+
+def test_generate_qr_code_with_colors():
+    """Test QR code generation endpoint with custom colors."""
+    response = client.post(
+        "/qr/generate",
+        json={
+            "data": "https://example.com",
+            "size": 10,
+            "fill_color": "#FF0000",  # Red
+            "back_color": "#FFFFFF"    # White
+        }
     )
     assert response.status_code == 200
     assert "qr_code" in response.json()


### PR DESCRIPTION
 Added the ability to customize QR code colors:
 - Added fill_color and back_color parameters to the QR code generation endpoint
 - Updated tests to verify color customization
 - Default colors remain black and white for backward compatibility