### PR TITLE
fix(ci): correct semantic-release configuration for alpha releases

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -409,8 +409,11 @@ jobs:
           CURRENT_VERSION=$(poetry version -s)
           echo "Current version: $CURRENT_VERSION"
           
+          # Force dev branch to be recognized
+          git checkout dev
+          
           # Run semantic release with alpha tag
-          semantic-release version
+          semantic-release version --prerelease alpha
           
           # Get the new version
           NEW_VERSION=$(poetry version -s)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,13 +56,18 @@ changelog_sections = [
 token = "GH_TOKEN"
 
 [tool.python_semantic_release.branches]
-main = "main"
-dev = "dev"
-release = "release/*"
+# Define which branches to release from
+allow_release_from_branches = ["main", "dev"]
 
-[tool.python_semantic_release.branches.dev]
-prerelease_token = "alpha"
-prerelease = true
+[tool.python_semantic_release.branch_patterns]
+main = "^main$"
+dev = "^dev$"
 
 [tool.python_semantic_release.branches.main]
-prerelease = false 
+match = "main"
+prerelease = false
+
+[tool.python_semantic_release.branches.dev]
+match = "dev"
+prerelease = true
+prerelease_token = "alpha" 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,18 +52,17 @@ changelog_sections = [
     "refactor"
 ]
 
+[tool.python_semantic_release.remote]
+token = "GH_TOKEN"
+
 [tool.python_semantic_release.branches]
+main = "main"
+dev = "dev"
+release = "release/*"
+
+[tool.python_semantic_release.branches.dev]
 prerelease_token = "alpha"
 prerelease = true
 
 [tool.python_semantic_release.branches.main]
-match = "main"
-prerelease = false
-
-[tool.python_semantic_release.branches.dev]
-match = "dev"
-prerelease = true
-prerelease_token = "alpha"
-
-[tool.python_semantic_release.remote]
-token = "GH_TOKEN" 
+prerelease = false 


### PR DESCRIPTION
- Update semantic-release branch configuration in pyproject.toml
- Add explicit branch handling for dev and main
- Add --prerelease alpha flag to dev branch releases
- Fix branch recognition issue in release workflow
- Add explicit git checkout for dev branch

This fixes the issue where no releases were being generated on the dev branch and ensures proper alpha versioning.