### PR TITLE
fix(ci): correct semantic-release command syntax

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -412,8 +412,8 @@ jobs:
           # Force dev branch to be recognized
           git checkout dev
           
-          # Run semantic release with alpha tag
-          semantic-release version --prerelease alpha
+          # Run semantic release
+          semantic-release version
           
           # Get the new version
           NEW_VERSION=$(poetry version -s)


### PR DESCRIPTION
- Remove incorrect --prerelease flag
- Rely on branch configuration for alpha releases
- Simplify release command to use configuration

This fixes the "unexpected extra argument" error in the dev release workflow.