### PR TITLE
fix(ci): resolve dev branch release configuration

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -412,8 +412,8 @@ jobs:
           # Force dev branch to be recognized
           git checkout dev
           
-          # Run semantic release
-          semantic-release version
+          # Run semantic release with explicit branch
+          semantic-release version --branch dev
           
           # Get the new version
           NEW_VERSION=$(poetry version -s)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ commit_parser = "conventional_commits"
 major_on_zero = false
 tag_format = "v{version}"
 allow_zero_version = true
+branch = "dev"
 commit_author = "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
 commit_message = "chore(release): {version} [skip ci]"
 changelog_sections = [
@@ -55,19 +56,11 @@ changelog_sections = [
 [tool.python_semantic_release.remote]
 token = "GH_TOKEN"
 
-[tool.python_semantic_release.branches]
-# Define which branches to release from
-allow_release_from_branches = ["main", "dev"]
-
-[tool.python_semantic_release.branch_patterns]
-main = "^main$"
-dev = "^dev$"
-
-[tool.python_semantic_release.branches.main]
-match = "main"
-prerelease = false
-
 [tool.python_semantic_release.branches.dev]
 match = "dev"
 prerelease = true
-prerelease_token = "alpha" 
+prerelease_token = "alpha"
+
+[tool.python_semantic_release.branches.main]
+match = "main"
+prerelease = false 


### PR DESCRIPTION
- Add default branch setting in pyproject.toml
- Simplify semantic-release branch configuration
- Add explicit --branch flag to release command
- Remove redundant branch configurations

This fixes the "branch 'dev' isn't in any release groups" error and enables proper alpha releases on the dev branch.