### PR TITLE
fix(ci): correct semantic-release version command in dev workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -412,8 +412,8 @@ jobs:
           # Force dev branch to be recognized
           git checkout dev
           
-          # Run semantic release with explicit branch
-          semantic-release version --branch dev
+          # Run semantic release (branch is configured in pyproject.toml)
+          semantic-release version
           
           # Get the new version
           NEW_VERSION=$(poetry version -s)


### PR DESCRIPTION
- Remove unsupported --branch flag from semantic-release command
- Rely on pyproject.toml branch configuration instead
- Maintain backward compatibility with semantic-release 9.x