### PR TITLE
fix(ci): update semantic-release branch configuration format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,10 @@ changelog_sections = [
 [tool.python_semantic_release.remote]
 token = "env: GH_TOKEN"
 
+[tool.python_semantic_release.branches]
+dev = { match = "dev", prerelease = true, prerelease_token = "alpha" }
+main = { match = "main", prerelease = false }
+
 [tool.python_semantic_release.branches.dev]
 match = "^dev$"
 prerelease = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,13 +57,4 @@ token = "env: GH_TOKEN"
 
 [tool.python_semantic_release.branches]
 dev = { match = "dev", prerelease = true, prerelease_token = "alpha" }
-main = { match = "main", prerelease = false }
-
-[tool.python_semantic_release.branches.dev]
-match = "^dev$"
-prerelease = true
-prerelease_token = "alpha"
-
-[tool.python_semantic_release.branches.main]
-match = "^main$"
-prerelease = false 
+main = { match = "main", prerelease = false } 


### PR DESCRIPTION
- Update branch configuration format in pyproject.toml to match semantic-release 9.x expectations
- Simplify branch configuration by using direct format instead of nested sections
- Fix "branch not in release groups" error by using correct configuration structure

Related to: Previous commit that removed --branch flag from workflow