### PR TITLE
fix(ci): simplify changelog update step after removing branch protection

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -138,7 +138,7 @@ jobs:
           poetry run coverage xml            # Generate coverage XML for artifact
 
       - name: Update Changelog
-        if: github.event_name == 'pull_request' || github.event_name == 'push'  # Run on all branches
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -149,10 +149,6 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           
-          # Determine current branch
-          CURRENT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          echo "Current branch: $CURRENT_BRANCH"
-          
           # Generate changelog
           semantic-release changelog
           
@@ -160,7 +156,7 @@ jobs:
           if [[ -n $(git status --porcelain CHANGELOG.md) ]]; then
             git add CHANGELOG.md
             git commit -m "docs: update CHANGELOG.md [skip ci]"
-            git push origin "$CURRENT_BRANCH"
+            git push origin HEAD:${{ github.ref }}
           fi
 
       - name: Upload coverage report
@@ -409,11 +405,8 @@ jobs:
           CURRENT_VERSION=$(poetry version -s)
           echo "Current version: $CURRENT_VERSION"
           
-          # Force dev branch to be recognized
-          git checkout dev
-          
-          # Run semantic release (branch is configured in pyproject.toml)
-          semantic-release version
+          # Run semantic release with explicit prerelease flag
+          semantic-release version --prerelease alpha
           
           # Get the new version
           NEW_VERSION=$(poetry version -s)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,5 +56,14 @@ changelog_sections = [
 token = "env: GH_TOKEN"
 
 [tool.python_semantic_release.branches]
-dev = { match = "dev", prerelease = true, prerelease_token = "alpha" }
-main = { match = "main", prerelease = false } 
+prerelease = true
+prerelease_token = "alpha"
+
+[tool.python_semantic_release.branches.main]
+match = "^main$"
+prerelease = false
+
+[tool.python_semantic_release.branches.dev]
+match = "^dev$"
+prerelease = true
+prerelease_token = "alpha" 


### PR DESCRIPTION
- Remove complex PR creation logic since branch protection is disabled
- Use direct push to current branch for changelog updates
- Maintain basic git configuration for bot commits