### PR TITLE
feat: add QR code size customization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,3 +345,46 @@ async def custom_exception_handler(request: Request, exc: CustomException):
         }
     )
 ```
+
+## Features
+
+- Generate QR codes from URLs
+- Custom QR code colors (fill and background)
+- Customizable QR code size and border
+- Base64 encoded output
+- Error handling with descriptive messages
+- API documentation with Swagger UI
+- Prometheus metrics for monitoring
+- Structured logging with JSON format
+- CI/CD pipeline with automated testing and releases
+- Semantic versioning with automated changelog
+
+## Usage
+
+### Generate a QR Code
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/qr-code/generate" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "url": "https://example.com",
+       "fill_color": "#000000",
+       "background_color": "#FFFFFF",
+       "box_size": 10,
+       "border": 4
+     }'
+```
+
+The response will contain a base64 encoded QR code image:
+
+```json
+{
+    "qr_code": "base64_encoded_image_data"
+}
+```
+
+You can customize the QR code appearance:
+- `fill_color`: The color of the QR code pattern (default: "#000000" - black)
+- `background_color`: The color of the QR code background (default: "#FFFFFF" - white)
+- `box_size`: Size of each QR code box in pixels (default: 10, range: 1-100)
+- `border`: Size of the QR code border in boxes (default: 4, range: 0-20)

--- a/app/api/v1/qr_code.py
+++ b/app/api/v1/qr_code.py
@@ -1,7 +1,7 @@
 """QR Code generation endpoint module."""
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, HttpUrl
+from pydantic import BaseModel, HttpUrl, Field
 import qrcode
 from io import BytesIO
 import base64
@@ -15,16 +15,33 @@ class QRCodeRequest(BaseModel):
     url: HttpUrl
     fill_color: str = "#000000"  # Default to black
     background_color: str = "#FFFFFF"  # Default to white
+    box_size: int = Field(
+        default=10,
+        ge=1,
+        le=100,
+        description="Size of each box in pixels",
+    )
+    border: int = Field(
+        default=4,
+        ge=0,
+        le=20,
+        description="Border size in boxes",
+    )
 
 
 @router.post("/generate")
 async def generate_qr_code(request: QRCodeRequest):
     """
-    Generate a QR code for the given URL with custom colors.
+    Generate a QR code for the given URL with custom colors and size.
 
     Args:
-        request (QRCodeRequest): Request containing URL and optional color
-            settings.
+        request (QRCodeRequest): Request containing URL and customization
+            options:
+            - url: The URL to encode
+            - fill_color: Color of the QR code pattern (default: "#000000")
+            - background_color: Color of the background (default: "#FFFFFF")
+            - box_size: Size of each box in pixels (default: 10)
+            - border: Border size in boxes (default: 4)
 
     Returns:
         dict: A dictionary containing the base64 encoded QR code image.
@@ -36,15 +53,16 @@ async def generate_qr_code(request: QRCodeRequest):
         qr = qrcode.QRCode(
             version=1,
             error_correction=qrcode.constants.ERROR_CORRECT_L,
-            box_size=10,
-            border=4,
+            box_size=request.box_size,
+            border=request.border,
         )
         qr.add_data(str(request.url))
         qr.make(fit=True)
 
         # Create the QR code image with custom colors
         qr_image = qr.make_image(
-            fill_color=request.fill_color, back_color=request.background_color
+            fill_color=request.fill_color,
+            back_color=request.background_color,
         )
 
         # Convert the image to base64


### PR DESCRIPTION
This PR adds new options to customize QR code size: box_size to control the size of each QR code box (1-100 pixels) and border to control the border width (0-20 boxes). These options give users more control over the QR code appearance and size.