### PR TITLE
ci(release): simplify semantic release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,14 +82,16 @@ jobs:
         uses: python-semantic-release/python-semantic-release@v9.15.0
         with:
           github_token: ${{ secrets.PAT_TOKEN }}
-          prerelease: ${{ inputs.prerelease || false }}
-          prerelease_token: ${{ inputs.prerelease_token }}
-          force: ${{ inputs.force != 'none' && inputs.force || '' }}
-          git_committer_name: "github-actions[bot]"
-          git_committer_email: "41898282+github-actions[bot]@users.noreply.github.com"
           changelog: true
           commit: true
           push: true
           build: true
           tag: true
           vcs_release: true
+
+      - name: Publish to GitHub Release Assets
+        uses: python-semantic-release/publish-action@v9.15.0
+        if: steps.release.outputs.released == 'true'
+        with:
+          github_token: ${{ secrets.PAT_TOKEN }}
+          tag: ${{ steps.release.outputs.tag }}


### PR DESCRIPTION
- Remove redundant git committer configuration (handled by pyproject.toml)
- Remove prerelease and force options (handled by workflow_dispatch)
- Keep publish action for GitHub release assets
- Align with python-semantic-release documentation