### PR TITLE
fix(release): pass workflow dispatch inputs to semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,9 @@ jobs:
         uses: python-semantic-release/python-semantic-release@v9.15.0
         with:
           github_token: ${{ secrets.PAT_TOKEN }}
+          prerelease: ${{ inputs.prerelease || false }}
+          prerelease_token: ${{ inputs.prerelease_token }}
+          force: ${{ inputs.force != 'none' && inputs.force || '' }}
           changelog: true
           commit: true
           push: true


### PR DESCRIPTION
- Add prerelease input handling
- Add force version bump input
- Add prerelease token input
- Enable manual control of release process

BREAKING CHANGE: Manual workflow dispatch now directly controls semantic-release behavior