### PR TITLE
ci(release): exclude semantic version commits from triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,10 @@ jobs:
       github.ref == 'refs/heads/main' &&
       github.actor != 'github-actions[bot]' &&
       !contains(github.event.head_commit.message, 'chore(release)') &&
-      !contains(github.event.head_commit.message, '[skip ci]')
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !contains(github.event.head_commit.message, 'docs: update CHANGELOG.md') &&
+      !contains(github.event.head_commit.message, 'docs(changelog)') &&
+      !matches(github.event.head_commit.message, '^[0-9]+\.[0-9]+\.[0-9]+$')
     needs: [lint, test]
     concurrency: release
 


### PR DESCRIPTION
1. Adds regex pattern `^[0-9]+\.[0-9]+\.[0-9]+$` to catch version commits like "2.0.0"
2. Maintains existing exclusions for other automated commits
3. Still allows manual triggers via workflow_dispatch
4. Prevents workflow loops from semantic-release's version bump commits
