### PR TITLE
ci: add poetry dependency caching to workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,15 @@ jobs:
           python-version: "3.11"
           cache: "pip"
 
+      - name: Cache Poetry Dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+
       - name: Install Poetry
         run: |
           pip install poetry==1.8.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,15 @@ jobs:
           python-version: "3.11"
           cache: "pip"
 
+      - name: Cache Poetry Dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+
       - name: Install Poetry
         run: |
           pip install poetry==1.8.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
 
+      - name: Cache Poetry Dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+
       - name: Install Poetry
         run: |
           pip install poetry==1.8.5


### PR DESCRIPTION
# Poetry Dependencies Caching in GitHub Actions

## Changes
- Added Poetry dependency caching to all GitHub Actions workflows (lint, test, and release)
- Implemented caching using `actions/cache@v3`
- Cache key is based on the runner OS and `poetry.lock` hash
- Added fallback restore-keys for partial cache matches

## Benefits
- Significantly reduces workflow execution time by reusing cached dependencies
- Cache automatically invalidates when dependencies change (via `poetry.lock`)
- Reduces GitHub Actions minutes consumption
- Minimizes network bandwidth usage for dependency downloads

## Implementation Details
Cache configuration:
- Cache location: `~/.cache/pypoetry`
- Primary cache key: `${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}`
- Fallback pattern: `${{ runner.os }}-poetry-`

## Testing
The caching mechanism is self-testing:
- First run will create the cache
- Subsequent runs will utilize the cache if dependencies haven't changed
- Cache automatically invalidates when `poetry.lock` changes

No breaking changes or additional configuration required.