### PR TITLE
fix: add `paths` filter to the `push` trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'pyproject.toml'
+      - '.github/workflows/release.yml'
+      - 'app/**'
   workflow_dispatch:
     inputs:
       prerelease:


### PR DESCRIPTION
Add `paths` filter to the `push` trigger:
   - `pyproject.toml` - to trigger on version changes
   - `.github/workflows/release.yml` - to trigger on workflow changes
   - `app/**` - to trigger on any application code changes

This ensures that the release workflow will be triggered when:
1. Changes are made to the version in `pyproject.toml`
2. Changes are made to the application code
3. Changes are made to the release workflow itself
4. Manual trigger through `workflow_dispatch`

The workflow will still maintain its other conditions:
1. Only runs on the main branch
2. Skips if the commit is from the bot or has `[skip ci]`
3. Runs CI checks before creating a release
4. Uses semantic versioning for releases

This should now properly trigger releases when there are version changes in `pyproject.toml` or other relevant changes.
