### PR TITLE
fix: removed path filters

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@ name: Release
 on:
   push:
     branches: [ main ]
-    paths:
-      - 'pyproject.toml'
-      - 'app/**'
   workflow_dispatch:
     inputs:
       prerelease:
@@ -49,8 +46,6 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.ref == 'refs/heads/main' &&
-      github.actor != 'github-actions[bot]' &&
-      github.actor != 'semantic-release' &&
       !contains(github.event.head_commit.message, '[skip ci]')
     concurrency:
       group: release


### PR DESCRIPTION
Key changes:
1. Removed the `paths` filter so it runs on any push to main
2. Simplified the `if` conditions to only check for:
   - Main branch
   - Not containing [skip ci] tag
3. Removed the actor checks since we want it to run after successful CI

This way, the workflow will:
1. Run CI (which includes lint and test)
2. If CI passes and we're on main branch, run the release job
3. Create a new release if there are relevant changes

The workflow will now automatically run after successful merges to main or direct commits to main, as long as the commit message doesn't contain [skip ci].
