### PR TITLE
fix(ci): activate virtual environment for semantic-release commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,11 +108,13 @@ jobs:
 
       - name: Validate Version Files
         run: |
-          poetry run semantic-release version --noop
-          poetry run semantic-release check-build
+          source .venv/bin/activate
+          .venv/bin/poetry run semantic-release version --noop
+          .venv/bin/poetry run semantic-release check-build
 
       - name: Verify Release
         if: success()
         run: |
-          poetry run semantic-release version --print
+          source .venv/bin/activate
+          .venv/bin/poetry run semantic-release version --print
           git describe --tags --abbrev=0


### PR DESCRIPTION
- Add virtual environment activation before running semantic-release
- Use full path to Poetry from virtual environment