### PR TITLE
fix(ci): remove redundant poetry installation in release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,17 +90,6 @@ jobs:
           cp artifact/pyproject.toml .
           chmod -R +x .venv/bin/
 
-      - name: Debug Environment
-        run: |
-          echo "Current directory:"
-          pwd
-          echo "Directory contents:"
-          ls -la
-          echo "Virtual env contents:"
-          ls -la .venv/bin || echo "No .venv/bin directory"
-          echo "Poetry location:"
-          which poetry || echo "Poetry not found in PATH"
-
       - name: Python Semantic Release
         uses: python-semantic-release/python-semantic-release@v8.7.2
         with:
@@ -109,12 +98,12 @@ jobs:
       - name: Validate Version Files
         run: |
           source .venv/bin/activate
-          .venv/bin/poetry run semantic-release version --noop
-          .venv/bin/poetry run semantic-release check-build
+          poetry run semantic-release version --noop
+          poetry run semantic-release check-build
 
       - name: Verify Release
         if: success()
         run: |
           source .venv/bin/activate
-          .venv/bin/poetry run semantic-release version --print
+          poetry run semantic-release version --print
           git describe --tags --abbrev=0


### PR DESCRIPTION
- Use Poetry from the shared virtual environment
- Remove duplicate Poetry installation step
- Keep consistent with test and lint workflows