### PR TITLE
fix(ci): use direct path to semantic-release executable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,12 +98,12 @@ jobs:
       - name: Validate Version Files
         run: |
           source .venv/bin/activate
-          poetry run semantic-release version --noop
-          poetry run semantic-release check-build
+          .venv/bin/semantic-release version --noop
+          .venv/bin/semantic-release check-build
 
       - name: Verify Release
         if: success()
         run: |
           source .venv/bin/activate
-          poetry run semantic-release version --print
+          .venv/bin/semantic-release version --print
           git describe --tags --abbrev=0


### PR DESCRIPTION
- Use .venv/bin/semantic-release directly
- Remove poetry run prefix
- Keep consistent with lint.yml and test.yml execution style