### PR TITLE
fix(ci): correct semantic-release command flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Validate Version Files
         run: |
           source .venv/bin/activate
-          .venv/bin/semantic-release version --noop
+          .venv/bin/semantic-release --noop version
           .venv/bin/semantic-release check-build
 
       - name: Verify Release


### PR DESCRIPTION
- Move --noop to top-level flag position
- Use correct --print flag for version display